### PR TITLE
Add item tag for available payment items

### DIFF
--- a/src/main/java/net/spudacious5705/shops/item/ModItems.java
+++ b/src/main/java/net/spudacious5705/shops/item/ModItems.java
@@ -2,8 +2,11 @@ package net.spudacious5705.shops.item;
 
 
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
+import net.minecraft.registry.RegistryKeys;
+import net.minecraft.registry.tag.TagKey;
 import net.minecraft.util.Identifier;
 import net.spudacious5705.shops.SpudaciousShops;
 import net.spudacious5705.shops.item.custom.ContractScroll;
@@ -15,6 +18,13 @@ public class ModItems {
     public static final Item PAYMENT_WARNING = register(new Item(new Item.Settings()), "payment_warning");
 
     public static final ContractScroll CONTRACT_SCROLL = register(new ContractScroll(new Item.Settings()), "contract_scroll");
+
+    public static final TagKey<Item> ALLOWED_PAYMENT_ITEMS_TAG = TagKey.of(RegistryKeys.ITEM, new Identifier(SpudaciousShops.MOD_ID, "allowed_payment_items"));
+
+    public static boolean isValidPaymentItem(ItemStack stack){
+        return Registries.ITEM.getEntryList(ModItems.ALLOWED_PAYMENT_ITEMS_TAG).isEmpty()
+            || stack.isIn(ModItems.ALLOWED_PAYMENT_ITEMS_TAG);
+    }
 
     private static <I extends Item> I register(I item, String id) {
         return Registry.register(Registries.ITEM, Identifier.of(SpudaciousShops.MOD_ID, id), item);

--- a/src/main/java/net/spudacious5705/shops/screen/ShopScreenHandlerOwner.java
+++ b/src/main/java/net/spudacious5705/shops/screen/ShopScreenHandlerOwner.java
@@ -501,7 +501,6 @@ public class ShopScreenHandlerOwner extends ScreenHandler {
     }
 
     class shop_trade_slot extends TogglableSlot {
-
         public shop_trade_slot(AbstractShopEntity.InventoryDelegate inventory, int index, int x, int y) {
             super(inventory, index, x, y);
             tabSellerSlots.add(this);
@@ -521,13 +520,18 @@ public class ShopScreenHandlerOwner extends ScreenHandler {
                 this.setStack(ItemStack.EMPTY);
                 return false;
             }
+            if (ModItems.isValidPaymentItem(stack)) {
+                return false;
+            }
             return true;
         }
 
         @Override
         public ItemStack insertStack(ItemStack stack, int count) {
+            if (ModItems.isValidPaymentItem(stack)) {
+                return stack;
+            }
             ItemStack oldStack = this.getStack();
-
             if(stack.getItem() == oldStack.getItem()){
                 count += oldStack.getCount();
                 if(count>64)count=64;


### PR DESCRIPTION
This pull request introduces a simple change that allows people to configure which items can be used as payment by adding them to the spudaciousshops/tags/items/allowed_payment_items.json file in datapacks. If this tag is not provided, the behavior remains unchanged.

For now, this is just a simple concept. I'm not entirely sure I didn’t overlook something, as the codebase is a bit hard to navigate.